### PR TITLE
Bugs/1.12/critical api not reobfuscated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,11 @@ compileJava {
             }
         }
         copy {
+            from project(':wolfarmor-api').sourceSets.main.allJava
+            into "$buildDir/generated/main/java"
+            expand version: shortVersion, mcversion: config.minecraft.version, modname: config.name, modid: config.modid
+        }
+        copy {
             from "$buildDir/generated/main/java"
             into "$buildDir/sources/main/java"
         }
@@ -145,7 +150,6 @@ shadowJar {
     dependsOn reobfJar
     dependencies {
         include dependency('org.spongepowered:mixin')
-        include dependency(':wolfarmor-api')
     }
 
     manifest.attributes(

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
         "extension": "universal",
         "major": 3,
         "minor": 6,
-        "patch": 1
+        "patch": 2
     },
     "forge": {
         "version": "14.23.5.2838"


### PR DESCRIPTION
Fix gradle file so shadowJar doesn't use pre-obfuscation sources
Fixes #109