### PR TITLE
Configuration setting to disable wolf armor recipes

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
     "version": {
         "major": 3,
         "minor": 7,
-        "patch": 2
+        "patch": 3
     },
     "minecraft": {
         "version": "1.12.2",

--- a/src/main/java/dev/satyrn/wolfarmor/config/WolfArmorConfig.java
+++ b/src/main/java/dev/satyrn/wolfarmor/config/WolfArmorConfig.java
@@ -59,6 +59,13 @@ public class WolfArmorConfig {
                     .setRequiresWorldReload()
                     .setConfigWidgetClassName("dev.satyrn.wolfarmor.client.gui.config.WolfInventorySizeWidget");
 
+    private final Setting<Boolean> enableRecipes = new BooleanSetting(true)
+            .setCategory(Configuration.CATEGORY_GENERAL)
+            .setName("allow_crafting")
+            .setComment("Allows or disallows players to craft the wolf armor items.")
+            .setSynchronizes(true)
+            .setRequiresMinecraftRestart();
+
     public BehaviorCategory behavior;
 
     /**

--- a/src/main/java/dev/satyrn/wolfarmor/config/WolfArmorConfig.java
+++ b/src/main/java/dev/satyrn/wolfarmor/config/WolfArmorConfig.java
@@ -278,7 +278,7 @@ public class WolfArmorConfig {
     /**
      * Checks whether or not the vanilla-based armor recipes are enabled or not
      * @return {@code true} if enabled, otherwise {@code false}
-     * @since 3.7.2
+     * @since 3.7.3
      */
     public boolean getEnableCrafting() { return this.enableRecipes.getCurrentValue(); }
 

--- a/src/main/java/dev/satyrn/wolfarmor/config/WolfArmorConfig.java
+++ b/src/main/java/dev/satyrn/wolfarmor/config/WolfArmorConfig.java
@@ -63,7 +63,6 @@ public class WolfArmorConfig {
             .setCategory(Configuration.CATEGORY_GENERAL)
             .setName("allow_crafting")
             .setComment("Allows or disallows players to craft the wolf armor items.")
-            .setSynchronizes(true)
             .setRequiresMinecraftRestart();
 
     public BehaviorCategory behavior;
@@ -275,6 +274,13 @@ public class WolfArmorConfig {
      */
     @SideOnly(Side.CLIENT)
     public boolean getStatsInGui() { return this.client.statsInGui.getCurrentValue(); }
+
+    /**
+     * Checks whether or not the vanilla-based armor recipes are enabled or not
+     * @return {@code true} if enabled, otherwise {@code false}
+     * @since 3.7.2
+     */
+    public boolean getEnableCrafting() { return this.enableRecipes.getCurrentValue(); }
 
     /**
      * Initializes the configuration

--- a/src/main/java/dev/satyrn/wolfarmor/factories/conditions/EnableCraftingCondition.java
+++ b/src/main/java/dev/satyrn/wolfarmor/factories/conditions/EnableCraftingCondition.java
@@ -1,0 +1,29 @@
+package dev.satyrn.wolfarmor.factories.conditions;
+
+import com.google.gson.JsonObject;
+import dev.satyrn.wolfarmor.WolfArmorMod;
+import dev.satyrn.wolfarmor.config.WolfArmorConfig;
+import net.minecraftforge.common.crafting.IConditionFactory;
+import net.minecraftforge.common.crafting.JsonContext;
+
+import java.util.function.BooleanSupplier;
+
+/**
+ * Condition factory that will return true if and only if the config setting
+ * {@link WolfArmorConfig#getEnableCrafting()} is enabled.
+ * @author Isabel Maskrey (satyrnidae)
+ * @since 3.7.3
+ */
+@SuppressWarnings("unused")
+public class EnableCraftingCondition implements IConditionFactory {
+    /**
+     * Returns a supplier which reads the setting from the configuration
+     * @param jsonContext The JSON context (unused)
+     * @param jsonObject The JSON object (unused)
+     * @return The value of {@link WolfArmorConfig#getEnableCrafting()}
+     */
+    @Override
+    public BooleanSupplier parse(JsonContext jsonContext, JsonObject jsonObject) {
+        return () -> WolfArmorMod.getConfig().getEnableCrafting();
+    }
+}

--- a/src/main/resources/assets/wolfarmor/advancements/_factories.json
+++ b/src/main/resources/assets/wolfarmor/advancements/_factories.json
@@ -1,0 +1,9 @@
+{
+  "_comment": [
+    "Checks the configuration setting enable_crafting to ensure that the recipe should or should not be enabled.",
+    "https://github.com/satyrnidae/wolfarmor/issues/83"
+  ],
+  "conditions": {
+    "enable_crafting_advancement": "dev.satyrn.wolfarmor.factories.conditions.EnableCraftingCondition"
+  }
+}

--- a/src/main/resources/assets/wolfarmor/advancements/recipes/combat/chainmail_wolf_armor.json
+++ b/src/main/resources/assets/wolfarmor/advancements/recipes/combat/chainmail_wolf_armor.json
@@ -42,5 +42,10 @@
       "has_the_item",
       "has_the_ingredients"
     ]
+  ],
+  "conditions": [
+    {
+      "type": "wolfarmor:enable_crafting_advancement"
+    }
   ]
 }

--- a/src/main/resources/assets/wolfarmor/advancements/recipes/combat/diamond_wolf_armor.json
+++ b/src/main/resources/assets/wolfarmor/advancements/recipes/combat/diamond_wolf_armor.json
@@ -42,5 +42,10 @@
       "has_the_item",
       "has_the_ingredients"
     ]
+  ],
+  "conditions": [
+    {
+      "type": "wolfarmor:enable_crafting_advancement"
+    }
   ]
 }

--- a/src/main/resources/assets/wolfarmor/advancements/recipes/combat/gold_wolf_armor.json
+++ b/src/main/resources/assets/wolfarmor/advancements/recipes/combat/gold_wolf_armor.json
@@ -42,5 +42,10 @@
       "has_the_item",
       "has_the_ingredients"
     ]
+  ],
+  "conditions": [
+    {
+      "type": "wolfarmor:enable_crafting_advancement"
+    }
   ]
 }

--- a/src/main/resources/assets/wolfarmor/advancements/recipes/combat/iron_wolf_armor.json
+++ b/src/main/resources/assets/wolfarmor/advancements/recipes/combat/iron_wolf_armor.json
@@ -42,5 +42,10 @@
       "has_the_item",
       "has_the_ingredients"
     ]
+  ],
+  "conditions": [
+    {
+      "type": "wolfarmor:enable_crafting_advancement"
+    }
   ]
 }

--- a/src/main/resources/assets/wolfarmor/advancements/recipes/combat/leather_wolf_armor.json
+++ b/src/main/resources/assets/wolfarmor/advancements/recipes/combat/leather_wolf_armor.json
@@ -42,5 +42,10 @@
       "has_the_item",
       "has_the_ingredients"
     ]
+  ],
+  "conditions": [
+    {
+      "type": "wolfarmor:enable_crafting_advancement"
+    }
   ]
 }

--- a/src/main/resources/assets/wolfarmor/recipes/_factories.json
+++ b/src/main/resources/assets/wolfarmor/recipes/_factories.json
@@ -1,0 +1,9 @@
+{
+  "_comment": [
+    "Checks the configuration setting enable_crafting to ensure that the recipe should or should not be enabled.",
+    "https://github.com/satyrnidae/wolfarmor/issues/83"
+  ],
+  "conditions": {
+    "enable_crafting": "dev.satyrn.wolfarmor.factories.conditions.EnableCraftingCondition"
+  }
+}

--- a/src/main/resources/assets/wolfarmor/recipes/chainmail_wolf_armor.json
+++ b/src/main/resources/assets/wolfarmor/recipes/chainmail_wolf_armor.json
@@ -18,5 +18,10 @@
   },
   "result": {
     "item": "wolfarmor:chainmail_wolf_armor"
-  }
+  },
+  "conditions": [
+    {
+      "type": "wolfarmor:enable_crafting"
+    }
+  ]
 }

--- a/src/main/resources/assets/wolfarmor/recipes/diamond_wolf_armor.json
+++ b/src/main/resources/assets/wolfarmor/recipes/diamond_wolf_armor.json
@@ -18,5 +18,10 @@
   },
   "result": {
     "item": "wolfarmor:diamond_wolf_armor"
-  }
+  },
+  "conditions": [
+    {
+      "type": "wolfarmor:enable_crafting"
+    }
+  ]
 }

--- a/src/main/resources/assets/wolfarmor/recipes/gold_wolf_armor.json
+++ b/src/main/resources/assets/wolfarmor/recipes/gold_wolf_armor.json
@@ -18,5 +18,10 @@
   },
   "result": {
     "item": "wolfarmor:gold_wolf_armor"
-  }
+  },
+  "conditions": [
+    {
+      "type": "wolfarmor:enable_crafting"
+    }
+  ]
 }

--- a/src/main/resources/assets/wolfarmor/recipes/iron_wolf_armor.json
+++ b/src/main/resources/assets/wolfarmor/recipes/iron_wolf_armor.json
@@ -18,5 +18,10 @@
   },
   "result": {
     "item": "wolfarmor:iron_wolf_armor"
-  }
+  },
+  "conditions": [
+    {
+      "type": "wolfarmor:enable_crafting"
+    }
+  ]
 }

--- a/src/main/resources/assets/wolfarmor/recipes/leather_wolf_armor.json
+++ b/src/main/resources/assets/wolfarmor/recipes/leather_wolf_armor.json
@@ -18,5 +18,10 @@
   },
   "result": {
     "item": "wolfarmor:leather_wolf_armor"
-  }
+  },
+  "conditions": [
+    {
+      "type": "wolfarmor:enable_crafting"
+    }
+  ]
 }


### PR DESCRIPTION
**Pull Request Description**

Added new configuration option ``B:allow_crafting``
Added a condition on the wolf armor recipes to check whether or not ``B:allow_crafting`` is enabled


**Additional remarks**

fixes #83 
Known issues: Advancements throw errors on load when the crafting recipes are disabled.  Not sure how to fix; conditions didn't work. Will try updating forge if necessary.

/cc @satyrnidae
